### PR TITLE
Fix for OTP 17.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,4 @@ test:
 	-@$(REBAR) skip_deps=true eunit
 clean:
 	@$(REBAR) clean
+	@rm cover.xml

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Usage
 
 Standalone:
 
-1. Build command line script
+1. Build command line script (WARNING: EUnit test for plugin may fail for OTP =< 17.3, due to a bug in `cover` app)
 
         $ make
 

--- a/test/rebar_covertool_tests.erl
+++ b/test/rebar_covertool_tests.erl
@@ -85,7 +85,7 @@ expected_cover_generated_files() ->
 		 "{covertool_ct, {\"test/ct.coverdata\", \"test/ct.coverage.xml\"}}.\n"]).
 
 -define(cover_spec,
-		["{export, \"../../test/ct.coverdata\"}.\n",
+		["{export, \"ct.coverdata\"}.\n",
 		"{incl_dirs, [\"../../test\", \"../../src\"]}.\n"]).
 
 make_tmp_dir() ->


### PR DESCRIPTION
OTP-12031 explains that previous "fix" OTP-11971 (introduced in 17.1) broke path handling in cover. This PR fixes the relative path in the test.