### PR TITLE
Update rebar to 2.6.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {eunit_opts, [verbose, {report, {eunit_surefire, [{dir, "."}]}}]}.
 {deps,
     [
-        {rebar, ".*", {git, "https://github.com/rebar/rebar.git", {tag, "2.5.1"}}}
+        {rebar, ".*", {git, "https://github.com/rebar/rebar.git", {tag, "2.6.0"}}}
     ]}.


### PR DESCRIPTION
Rebar 2.5.1 have some issues with recursive coverage and common tests. 2.6.0 works well.