### PR TITLE
Only fetch rebar if $(REBAR) undefined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,17 @@
 #!/usr/bin/make
-REBAR?=rebar
 
-.PHONY : all deps compile test clean
-all: deps compile test
+ifdef REBAR
+deps:
+	$(info REBAR is $(REBAR))
+else
+REBAR=rebar
 deps:
 	@$(REBAR) get-deps update-deps
 	$(MAKE) -C deps/rebar
+endif
+
+.PHONY : all deps compile test clean
+all: deps compile test
 compile:
 	@$(REBAR) compile escriptize
 test:


### PR DESCRIPTION
If $REBAR is defined, assume rebar already exists,
and is built outside of this Makefile.

This fixes our build for a dependent project where DEPS_DIR
is set to a root dir not in this particular app.