### PR TITLE
Makefile: Move 'all' back to top so its default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 #!/usr/bin/make
 
+.PHONY : all deps compile test clean
+all: deps compile test
 ifdef REBAR
 deps:
 	$(info REBAR is $(REBAR))
@@ -9,9 +11,6 @@ deps:
 	@$(REBAR) get-deps update-deps
 	$(MAKE) -C deps/rebar
 endif
-
-.PHONY : all deps compile test clean
-all: deps compile test
 compile:
 	@$(REBAR) compile escriptize
 test:


### PR DESCRIPTION
I repositioned the 'deps' target in a previous commit,
that added an ifdef in case REBAR was already defined:
71dd390e8222c0dbbcc376564910ef03210aa46d

However, I didn't realize that Makefiles depend on having
their default targets always at the top (it doesn't just always
magically default to 'all').

Therefore, this restores the intended order of the targets.