### PR TITLE
Restore covertool compatibility with R16

### DIFF
--- a/src/covertool.erl
+++ b/src/covertool.erl
@@ -83,7 +83,7 @@ generate_report(Config, Modules) ->
     Prolog = ["<?xml version=\"1.0\" encoding=\"utf-8\"?>\n",
               "<!DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-04.dtd\">\n"],
 
-    {MegaSecs, Secs, MicroSecs} = erlang:timestamp(),
+    {MegaSecs, Secs, MicroSecs} = os:timestamp(),
     Timestamp = MegaSecs * 1000000000 + Secs * 1000 + (MicroSecs div 1000), % in milliseconds
 
     Version = "1.9.4.1", % emulate Cobertura 1.9.4.1


### PR DESCRIPTION
Hi, 

We use this tool at my company for coverage analysis on our Erlang projects. Unfortunately, much of our code is still pinned to R16B03-1. The latest commit to this repo for R18 compatibility broke R16 compatibility, because `erlang:timestamp/0` is not available.

I have updated timestamp calculation to use `os:timestamp/0` rather than `erlang:timestamp/0`. This allows compatibility with both R18 and R16.

Thanks in advance for reviewing.