### PR TITLE
Ensure untyped record doesn't error

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,4 @@
+{erl_opts, [nowarn_untyped_record]}.
 {eunit_opts, [verbose, {report, {eunit_surefire, [{dir, "."}]}}]}.
 {deps,
     [


### PR DESCRIPTION
When included in other projects, with rebar2, the untyped config
record causes error... don't let it.