### PR TITLE
Improve error reporting and handling of missing files

### DIFF
--- a/src/rebar3_covertool_gen.erl
+++ b/src/rebar3_covertool_gen.erl
@@ -28,7 +28,7 @@ do(State) ->
     InputFiles = input_files(),
     Apps = rebar_state:project_apps(State),
     case generate( OutputFiles, InputFiles, Apps ) of
-        {ok, _} ->
+        ok ->
             {ok, State};
         Error ->
             {error, {?MODULE, Error}}
@@ -48,7 +48,7 @@ output_files() ->
 
 input_files() ->
     CoverDataFiles = ["eunit.coverdata", "ct.coverdata"],
-    ["_build/test/cover/" ++ File || File <- CoverDataFiles].
+    ["_build/test/cover/" ++ File || File <- CoverDataFiles, file_exists(File)].
     
 
 generate( OutputFiles, InputFiles, Apps ) ->
@@ -98,4 +98,12 @@ generate_app( App, Result ) ->
 outdir() ->
     "_build/test/covertool".
 
-        
+file_exists(Filename) ->
+    case file:read_file_info(Filename) of
+        {ok, _} ->
+            true;
+        {error, enoent} ->
+            false;
+        Reason ->
+            exit(Reason)
+    end.

--- a/src/rebar3_covertool_gen.erl
+++ b/src/rebar3_covertool_gen.erl
@@ -27,8 +27,12 @@ do(State) ->
     OutputFiles = output_files(),
     InputFiles = input_files(),
     Apps = rebar_state:project_apps(State),
-    generate( OutputFiles, InputFiles, Apps ),
-    {ok, State}.
+    case generate( OutputFiles, InputFiles, Apps ) of
+        {ok, _} ->
+            {ok, State};
+        Error ->
+            {error, {?MODULE, Error}}
+    end.
 
 
 format_error(Reason) ->
@@ -44,7 +48,7 @@ output_files() ->
 
 input_files() ->
     CoverDataFiles = ["eunit.coverdata", "ct.coverdata"],
-    [["_build/test/cover/" | File] || File <- CoverDataFiles].
+    ["_build/test/cover/" ++ File || File <- CoverDataFiles].
     
 
 generate( OutputFiles, InputFiles, Apps ) ->


### PR DESCRIPTION
Without this patch generation of xml  fails silently when one of ct/eunit.coverdata files is missing.