### PR TITLE
Add include_apps option to allow including additional dependencies to rebar3 coverage reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,16 @@ Configure rebar3 to generate reports in `Cobertura` format:
 ```
 {project_plugins, [rebar_covertool]}.
 {cover_export_enabled, true}.
-{covertool, [{coverdata_files, ["ct.coverdata", "eunit.coverdata"]}]}.
+{covertool, [{coverdata_files, ["ct.coverdata", "eunit.coverdata"]},
+             {include_apps, [dep0, dep1]}]}.
+```
+
+The `include_apps` option allows specifying a list of dependent OTP applications to include in the coverage export (default: `[]`). Note that the coverage data must be included in the input `.coverdata` file in order for any values to be populated in the output XML file. This can be done using the [ct cover spec file](http://erlang.org/doc/apps/common_test/cover_chapter.html#id85714).
+
+The `include_apps` option can also be specified via the command line as a CSV of application names, e.g.:
+
+```
+rebar3 covertool generate -a"dep0,dep1"
 ```
 
 ## Mix
@@ -65,7 +74,6 @@ end
 Screenshots
 -----------
 
-![Screenshot1](covertool/raw/master/screenshots/shot1.png)
+![Screenshot1](screenshots/shot1.png)
 
-![Screenshot2](covertool/raw/master/screenshots/shot2.png)
-
+![Screenshot2](screenshots/shot2.png)


### PR DESCRIPTION
This change introduces the `include_apps` option to the rebar3 covertool pluigin, to allow users to specify a list of dependent apps to also generate cobertura coverage reports for. This can be very helpful if you have some libraries that cannot be effectively tested on their own, but are tested via ct in a higher level test.

As the README notes, you'll only get coverage data if you include the beams from the deps in your initital coverage report. However, this allows you to bring the data already included (separately) in the `.coverdata` file into a Cobertura report that is keyed by application name.

Lastly, this fixes a bug introduced by idubrov/covertool#35, where the ebin directory for applications weren't included in the rebar3 coverage report, causing empty reports to be generated.