### PR TITLE
Add support for `prefix_len` in rebar3 plugin, remove rebar3 boilerplate in package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ Configure rebar to generate reports in `Cobertura` format:
 {cover_export_enabled, true}.
 {covertool_eunit, {".eunit/eunit.coverdata", "eunit.coverage.xml"}}. % Source file name, output report file name
 {covertool_ct, {"ct.coverdata", "ct.coverage.xml"}}. % Source file name, output report file name
-{covertool_prefix_len, 2}. % Optional: Use module prefix as (imaginary) package name
+{covertool_prefix_len, 2}. % Optional: include the module prefix in the package name
 ```
+
+The `covertool_prefix_len` option allows including the first *n* sections of the '_'-delimited module name in the package name. For example, with a `covertool_prefix_len` of 2 and a module named `app0_worker_srv_sup`, the term `app0.worker` would be added to the end of the package name. Defaults to 0 (no module prefix included).
 
 ## Rebar3
 
@@ -48,7 +50,8 @@ Configure rebar3 to generate reports in `Cobertura` format:
 {project_plugins, [rebar_covertool]}.
 {cover_export_enabled, true}.
 {covertool, [{coverdata_files, ["ct.coverdata", "eunit.coverdata"]},
-             {include_apps, [dep0, dep1]}]}.
+             {include_apps, [dep0, dep1]},
+             {prefix_len, 2}]}. % Optional: Use module prefix as (imaginary) package name
 ```
 
 The `include_apps` option allows specifying a list of dependent OTP applications to include in the coverage export (default: `[]`). Note that the coverage data must be included in the input `.coverdata` file in order for any values to be populated in the output XML file. This can be done using the [ct cover spec file](http://erlang.org/doc/apps/common_test/cover_chapter.html#id85714).
@@ -57,6 +60,12 @@ The `include_apps` option can also be specified via the command line as a CSV of
 
 ```
 rebar3 covertool generate -a"dep0,dep1"
+```
+
+The `prefix_len` option allows including the first *n* sections of the '_'-delimited module name in the package name. For example, with a `prefix_len` of 2 and a module named `app0_worker_srv_sup`, the term `app0.worker` would be added to the end of the package name. Defaults to 0 (no module prefix included). This option can also be specified via the command line, e.g.:
+
+```
+rebar3 covertool generate -p2
 ```
 
 ## Mix


### PR DESCRIPTION
This change adds support for passing the `prefix_len` configuration parameter into the `covertool` section of the rebar3 `rebar.config` file, for parity with the `covertool_prefix_len` option from rebar2.

This also introduces a package naming adjustment strip out tedious rebar3 source path segments from the package name. For example, where before you might have a package name like `app0._build.default.lib.app0.src`, this would be replaced with simply `app0` as the package name. Outside rebar3 paths, there should be no change. This is compatible with the prefix_len support as well.